### PR TITLE
Create requirements.txt and add colorama

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+colorama


### PR DESCRIPTION
Running `python -m breachman.terminal` gives the error `ModuleNotFoundError: No module named 'colorama'` if colorama is not installed for the current python.